### PR TITLE
Add holder.js for placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ npm start
 npm build
 ```
 
+[Holder](http://holderjs.com/) is included to display placeholder images. If you want to add your own assets, e.g. images and fonts, place them inside folders inside of an assets folder at the root of the project. For example, anything placed in assets/img/ will be copied to dist/img/. Don't add assets directly to your dist/ folder. They will be deleted when dist/ is refreshed.
+
 ## Acknowledgments
 
 Forked from bassjobsen's [empty-bootstrap-project-gulp](https://github.com/bassjobsen/empty-bootstrap-project-gulp), showing that Zurb's Panini is not just for Foundation. The great Panini, and the initial Panini starter projects, were made by [Zurb](https://github.com/zurb).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,6 +35,7 @@ gulp.task('clean', function() {
 // Copies assets
 gulp.task('copy', function() {
   gulp.src(['assets/**/*']).pipe(gulp.dest('dist'));
+  gulp.src('node_modules/holderjs/holder.min.js').pipe(gulp.dest('dist/temp'));
 });
 
 var sassOptions = {

--- a/html/includes/footerjavascripts.html
+++ b/html/includes/footerjavascripts.html
@@ -2,3 +2,5 @@
     <!--script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
     <script src="https://cdn.rawgit.com/HubSpot/tether/v1.2.0/dist/js/tether.min.js"></script-->
     <script src="{{ root }}js/app.js"></script>
+    <!-- holderjs for temporary placeholder images. -->
+    <script src="{{ root }}temp/holder.min.js"></script>

--- a/html/pages/index.html
+++ b/html/pages/index.html
@@ -23,6 +23,7 @@ title: Home
         <h1>Make Your Beautiful!</h1>
         <p class="lead">Edit the \HTML and \SCSS to create mockups and design patterns.
             <br>Or go crazy and create a template for your favorite CMS.</p>
+            <img src="holder.js/128x128">
     </div>
 
 </div><!-- /.container -->

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "gulp-postcss": "^6.1.0",
     "gulp-sass": "^2.3.2",
     "gulp-sourcemaps": "^1.6.0",
+    "holderjs": "^2.9.4",
     "mq4-hover-shim": "^0.3.0",
     "panini": "^1.3.0",
     "rimraf": "^2.5.2",


### PR DESCRIPTION
Add holderjs to package.json. Added holder.min.js to copy in gulpfile.js (uses a dist/temp folder). Added an example holder image to index.html. Added a reference to README.me.