### PR TITLE
Fix run build

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Start the project with `npm start`. The Sass and HTML files will be compiled in 
 
 ```bash
 npm start
-npm run build
+npm run build --production
 ```
 
 [Holder](https://github.com/imsky/holder/) is included to display placeholder images. If you want to add your own assets, e.g. images and fonts, don't add them directly to the /dist folder. They will be deleted each time the project is refreshed. Instead, place them inside folders inside of an /assets folder at the root of the project. For example, anything placed in /assets/img will be copied to /dist/img.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Start the project with `npm start`. The Sass and HTML files will be compiled in 
 
 ```bash
 npm start
-npm build
+npm run build
 ```
 
 [Holder](https://github.com/imsky/holder/) is included to display placeholder images. If you want to add your own assets, e.g. images and fonts, don't add them directly to the /dist folder. They will be deleted each time the project is refreshed. Instead, place them inside folders inside of an /assets folder at the root of the project. For example, anything placed in /assets/img will be copied to /dist/img.

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ npm install
 
 ## Start
 
-Start the project with `npm start`. The Sass and HTML files will be compiled in the background as you save changes to them. Compile minified CSS and JS to your dist folder with `npm build`.
+Start the project with `npm start`. Then edit the files in your /html, /sass, and /js folders. The Sass and HTML files will be compiled in the background as you save changes to them. Compile minified CSS and JS to your dist folder with `npm run build`.
 
 ```bash
 npm start
-npm run build --production
+npm run build
 ```
 
 [Holder](https://github.com/imsky/holder/) is included to display placeholder images. If you want to add your own assets, e.g. images and fonts, don't add them directly to the /dist folder. They will be deleted each time the project is refreshed. Instead, place them inside folders inside of an /assets folder at the root of the project. For example, anything placed in /assets/img will be copied to /dist/img.

--- a/html/includes/defaulthead.html
+++ b/html/includes/defaulthead.html
@@ -1,0 +1,9 @@
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+
+    <title> {{title}} </title>
+
+    <link rel="stylesheet" href="{{root}}css/app.css">
+</head>

--- a/html/includes/footerjavascripts.html
+++ b/html/includes/footerjavascripts.html
@@ -1,6 +1,0 @@
-    <!-- jQuery first, then Bootstrap JS. -->
-    <!--script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-    <script src="https://cdn.rawgit.com/HubSpot/tether/v1.2.0/dist/js/tether.min.js"></script-->
-    <script src="{{ root }}js/app.js"></script>
-    <!-- holderjs for temporary placeholder images. -->
-    <script src="{{ root }}temp/holder.min.js"></script>

--- a/html/includes/javascriptincludes.html
+++ b/html/includes/javascriptincludes.html
@@ -1,0 +1,4 @@
+<!-- Javascript -->
+<script src="{{ root }}js/app.js"></script>
+<!-- holderjs for temporary placeholder images. -->
+<script src="{{ root }}temp/holder.min.js"></script>

--- a/html/layouts/default.html
+++ b/html/layouts/default.html
@@ -1,18 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <!-- Required meta tags always come first -->
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta http-equiv="x-ua-compatible" content="ie=edge">
-
-        <title> Bootstrap 4 Prototyping Glue :: {{title}}</title>
-
-        <!--Bootstrap CSS -->
-        <link rel="stylesheet" href="{{root}}css/app.css">
-    </head>
+    {{> defaulthead}}
     <body>
         {{> body}}
-        {{> footerjavascripts}}
+        {{> javascriptincludes}}
     </body>
 </html>

--- a/html/pages/index.html
+++ b/html/pages/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Home
+title: Bootstrap 4 Prototyping Glue - Home
 ---
 <nav class="navbar navbar-fixed-top navbar-dark bg-inverse">
     <a class="navbar-brand" href="index.html">Bootstrap 4 Prototyping Glue</a>
@@ -20,9 +20,9 @@ title: Home
 <div class="container">
 
     <div class="starter-template">
-        <h1>Make Your Beautiful!</h1>
-        <p class="lead">Edit the \HTML and \SCSS to create mockups and design patterns.
-            <br>Or go crazy and create a template for your favorite CMS.</p>
+        <h1>Make Your Beautiful Styles!</h1>
+        <p class="lead">Turn this page into your own design patterns and theme mockups.
+            <br>Simply fire up your editor and hack the files under /html, /scss, and /js.</p>
             <img src="holder.js/128x128">
     </div>
 

--- a/html/pages/styles.html
+++ b/html/pages/styles.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Base Styles
+title: Bootstrap 4 Prototyping Glue - Base Styles
 ---
 <nav class="navbar navbar-fixed-top navbar-dark bg-inverse">
     <a class="navbar-brand" href="index.html">Bootstrap 4 Prototyping Glue</a>
@@ -32,6 +32,12 @@ title: Base Styles
             </div>
             <div class="alert alert-danger" role="alert">
                 <strong>Oh snap!</strong> Change a few things up and try submitting again.
+            </div>
+            <div class="alert alert-warning alert-dismissible fade in" role="alert">
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <strong>Holy guacamole!</strong> You should check in on some of those fields below.
             </div>
         </div>
 
@@ -177,6 +183,19 @@ title: Base Styles
                 <li>Facilisis in pretium nisl aliquet</li>
                 <li>Nulla volutpat aliquam velit</li>
             </ol>
+        </div>
+
+        <div class="card card-block">
+            <h1 class="card-title">Media Object</h1>
+            <div class="media">
+                <a class="media-left" href="#">
+                    <img class="media-object" src="holder.js/64x64" alt="Generic placeholder image">
+                </a>
+                <div class="media-body">
+                    <h4 class="media-heading">Media heading</h4>
+                    Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+                </div>
+            </div>
         </div>
 
         <div class="card card-block">

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,1 @@
+// Custom JS

--- a/package.json
+++ b/package.json
@@ -10,21 +10,24 @@
     "gulp": "^3.9.1",
     "gulp-clean": "^0.3.2",
     "gulp-concat": "^2.6.0",
+    "gulp-cssnano": "^2.1.2",
+    "gulp-if": "^2.0.2",
     "gulp-postcss": "^6.1.0",
     "gulp-sass": "^2.3.2",
     "gulp-sourcemaps": "^1.6.0",
+    "gulp-uglify": "^2.0.0",
     "holderjs": "^2.9.4",
     "mq4-hover-shim": "^0.3.0",
     "panini": "^1.3.0",
     "rimraf": "^2.5.2",
-    "tether": "^1.1.2"
+    "yargs": "^6.0.0"
   },
   "engines": {
     "node": ">=0.10.1"
   },
   "scripts": {
     "start": "gulp",
-    "build": "gulp build"
+    "build": "gulp build --production"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updated so `npm run build` (or `gulp build -production`) will output minified CSS and JS. Various other fixes and improvements.